### PR TITLE
Add context manager support

### DIFF
--- a/rarfile.py
+++ b/rarfile.py
@@ -463,6 +463,12 @@ class RarFile(object):
 
         self._parse()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
     def setpassword(self, password):
         '''Sets the password to use when extracting.'''
         self._password = password


### PR DESCRIPTION
`zipfile` supports context manager from 2.7, so the code can be written like this:

``` python
with zipfile.ZipFile('test.zip') as zip_file:
    # Do something
    pass
```

This commit adds such feature to `rarfile` (fix: `.pyc` file not included now).
