### PR TITLE
listinfo now works on incomplete rar sets

### DIFF
--- a/rarfile.py
+++ b/rarfile.py
@@ -756,15 +756,19 @@ class RarFile(object):
                 h = self._parse_header(fd)
             if not h:
                 if more_vols:
-                    volume += 1
-                    volfile = self._next_volname(volfile)
-                    fd.close()
-                    fd = open(volfile, "rb")
-                    self._fd = fd
-                    more_vols = 0
-                    endarc = 0
-                    self._vol_list.append(volfile)
-                    continue
+                    try:
+                        volume += 1
+                        volfile = self._next_volname(volfile)
+                        fd.close()
+                        fd = open(volfile, "rb")
+                        self._fd = fd
+                        more_vols = 0
+                        endarc = 0
+                        self._vol_list.append(volfile)
+                    except IOError:
+                        pass
+                    else:
+                        continue
                 break
             h.volume = volume
             h.volume_file = volfile


### PR DESCRIPTION
rarfile throws an error when trying to parse incompete rarsets. This quick fix enables me to get an (incomplete) file listing for an incomplete set of rarfiles.
