### PR TITLE
Ask unrar stop switches scanning

### DIFF
--- a/rarfile.py
+++ b/rarfile.py
@@ -1189,6 +1189,7 @@ class RarFile(object):
             raise ValueError("Cannot use unrar directly on memory buffer")
         cmd = [UNRAR_TOOL] + list(OPEN_ARGS)
         add_password_arg(cmd, psw)
+        cmd.append("--")
         cmd.append(rarfile)
 
         # not giving filename avoids encoding related problems


### PR DESCRIPTION
If my file have name "-foo.bar", unrar parse this as switches and not found my file