### PR TITLE
Ensure the strerror() function returns None when there are no failures.

### DIFF
--- a/rarfile.py
+++ b/rarfile.py
@@ -503,6 +503,7 @@ class RarFile(object):
 
         self._info_list = []
         self._info_map = {}
+        self._parse_error = None
         self._needs_password = False
         self._password = None
         self._crc_check = crc_check


### PR DESCRIPTION
Calling the `strerror()` function on an uncorrupted RAR file throws a traceback:

    >>> rarfp = rarfile.RarFile('foo.rar')
    >>> rarfp.strerror()
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/usr/local/lib/python3.5/site-packages/rarfile.py", line 725, in strerror
        return self._parse_error
    AttributeError: 'RarFile' object has no attribute '_parse_error'
    >>>

This is because the `self._parse_error` variable is not defined in the RarFile constructor. The fix is simple: initialize that variable to None.