### PR TITLE
Concatenate strings instead of an instance

### DIFF
--- a/rarfile.py
+++ b/rarfile.py
@@ -759,7 +759,9 @@ class RarFile(object):
         self._fd = fd
         id = fd.read(len(RAR_ID))
         if id != RAR_ID:
-            raise NotRarFile("Not a Rar archive: {}".format(self.rarfile))
+            if isinstance(self.rarfile, str):
+                raise NotRarFile("Not a Rar archive: {}".format(self.rarfile))
+            raise NonRarFile("Not a Rar archive")
 
         volume = 0  # first vol (.rar) is 0
         more_vols = 0

--- a/rarfile.py
+++ b/rarfile.py
@@ -759,7 +759,7 @@ class RarFile(object):
         self._fd = fd
         id = fd.read(len(RAR_ID))
         if id != RAR_ID:
-            raise NotRarFile("Not a Rar archive: "+self.rarfile)
+            raise NotRarFile("Not a Rar archive: {}".format(self.rarfile))
 
         volume = 0  # first vol (.rar) is 0
         more_vols = 0


### PR DESCRIPTION
When providing a filehander to the `RarFile` constructor, `this.rarfile` will not be a path (str), but an instance.
Due the error of concatenating an instance to a string when constructing a `NonRarFile` exception, an `TypeError` is raised instead of the expected `NotRarFile` exception.

Example stacktrace (py.test):
```
self = <rarfile.RarFile object at 0x7fbd02c9d810>

    def _parse_real(self):
        fd = XFile(self.rarfile)
        self._fd = fd
        id = fd.read(len(RAR_ID))
        if id != RAR_ID:
>           raise NotRarFile("Not a Rar archive: "+self.rarfile)
E           TypeError: cannot concatenate 'str' and 'instance' objects

../../.virtualenvs/byte-user-milter/local/lib/python2.7/site-packages/rarfile.py:789: TypeError

```

With this patch the NonRarFile message will contain the following:
```
NotRarFile: Not a Rar archive: <StringIO.StringIO instance at 0x7fa600b43098>
```
