### PR TITLE
Fixed bug when calling rarfp.open() on a RarInfo structure.

### DIFF
--- a/rarfile.py
+++ b/rarfile.py
@@ -935,9 +935,14 @@ class CommonParser(object):
         """
         return self._info_list
 
-    def getinfo(self, fname):
+    def getinfo(self, member):
         """Return RarInfo for filename
         """
+        if isinstance(member, RarInfo):
+            fname = member.filename
+        else:
+            fname = member
+
         # accept both ways here
         if PATH_SEP == '/':
             fname2 = fname.replace("\\", "/")


### PR DESCRIPTION
The following test code fails with a traceback:

```
$ cat foo.py
import rarfile

rarfp = rarfile.RarFile('foo.rar')
first_file = rarfp.infolist()[0]
fp = rarfp.open(first_file)

$ python3 foo.py
Traceback (most recent call last):
  File "foo.py", line 5, in <module>
    fp = rarfp.open(first_file)
  File "/usr/local/lib/python3.4/dist-packages/rarfile.py", line 735, in open
    inf = self.getinfo(fname)
  File "/usr/local/lib/python3.4/dist-packages/rarfile.py", line 704, in getinfo
    return self._file_parser.getinfo(fname)
  File "/usr/local/lib/python3.4/dist-packages/rarfile.py", line 943, in getinfo
    fname2 = fname.replace("\\", "/")
AttributeError: 'Rar3Info' object has no attribute 'replace'
$
```

The `rarfp.open()` method definition allows users to specify a RarInfo object instead of a string filename, but the `getinfo()` implementation doesn't check for this case. My pull request fixes this issue by adding an `isinstance` check.

Thanks for adding RAR5 support, by the way! It's really useful and I'm glad to see it in this module.
