### PR TITLE
include all test files in archive

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include README.rst Makefile MANIFEST.in LICENSE dumprar.py
 include doc/*.rst doc/Makefile doc/conf.py doc/make.bat
-include test/Makefile test/*.sh test/files/*.rar test/files/*.exp
+include test/Makefile test/*.sh test/files/*.rar test/files/*.r[0-9][0-9] test/files/*.exp


### PR DESCRIPTION
test/files/rar3-old.r00 and test/files/rar3-old.r01 are missing from
rarfile-3.0.tar.gz