### PR TITLE
py2.6 compat: only use memoryview on supported python versions

### DIFF
--- a/rarfile.py
+++ b/rarfile.py
@@ -1625,7 +1625,10 @@ class RAR5Parser(CommonParser):
             return None
         data_offset = fd.tell()
 
-        calc_crc = rar_crc32(memoryview(hdata)[4:])
+        if sys.version_info < (2, 7, 0):
+            calc_crc = rar_crc32(hdata[4:])
+        else:
+            calc_crc = rar_crc32(memoryview(hdata)[4:])
         if header_crc != calc_crc:
             # header parsing failed.
             self._set_error('Header CRC error: exp=%x got=%x (xlen = %d)',


### PR DESCRIPTION
rarfile is currently not working on legacy platforms restricted to python 2.6. this patch is supposed to restore compatibility to python 2.6 while maintaining performance on memoryview enabled platforms.