### PR TITLE
Fixes for multivolume RAR3 with encrypted headers

### DIFF
--- a/rarfile.py
+++ b/rarfile.py
@@ -976,6 +976,7 @@ class CommonParser(object):
                     more_vols = False
                     endarc = False
                     self._vol_list.append(volfile)
+                    self._main = None
                     continue
                 break
             h.volume = volume
@@ -983,7 +984,7 @@ class CommonParser(object):
 
             if h.type == RAR_BLOCK_MAIN and not self._main:
                 self._main = h
-                if h.flags & RAR_MAIN_NEWNUMBERING:
+                if volume == 0 and (h.flags & RAR_MAIN_NEWNUMBERING):
                     # RAR 2.x does not set FIRSTVOLUME,
                     # so check it only if NEWNUMBERING is used
                     if (h.flags & RAR_MAIN_FIRSTVOLUME) == 0:


### PR DESCRIPTION
The current implementation never cleans up previous volume headers from
the main RAR3 object when moving to the next volume. The `self._main`
object gets populated from the first volume and doesn't change for
subsequent volumes, so the conditional in the `_parse_header()` method
evaluates to True for all blocks of all headers. However, in encrypted
RAR3/4 volumes the archive header (type `0x73`) is not encrypted, so
doesn't need to be decrypted.

This change removes the old header when the next volume is read.

With proper headers flags are being checked against the
`RAR_MAIN_FIRSTVOLUME` flag in `_parse_real()` for each volume and this
will fail for volumes different than the first one. This problem is
fixed by triggering the check only for the starting volume.