### PR TITLE
Add the .sfx test files to MANIFEST.in for inclusion in pypi tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include README.rst Makefile MANIFEST.in LICENSE dumprar.py
 include doc/*.rst doc/*.awk doc/Makefile doc/conf.py doc/make.bat
-include test/Makefile test/*.sh test/files/*.rar test/files/*.r[0-9][0-9] test/files/*.exp
+include test/Makefile test/*.sh test/files/*.rar test/files/*.r[0-9][0-9] test/files/*.exp test/files/*.sfx


### PR DESCRIPTION
The .sfx files for testing self-extraction support aren't included in MANIFEST.in so are missing from the pypi tarball. This will include them.