### PR TITLE
Rewind DirectReader before reading

### DIFF
--- a/rarfile.py
+++ b/rarfile.py
@@ -2461,6 +2461,11 @@ class DirectReader(RarExtFile):
     def _read(self, cnt):
         """Read from potentially multi-volume archive."""
 
+        whence = self._cur.add_size - self._cur_avail
+        self._fd.seek(self._inf.header_offset, self._cur.add_size - self._cur_avail)
+        if whence == 0:
+            self._cur = self._parser._parse_header(self._fd)
+
         buf = []
         while cnt > 0:
             # next vol needed?

--- a/rarfile.py
+++ b/rarfile.py
@@ -2462,7 +2462,7 @@ class DirectReader(RarExtFile):
         """Read from potentially multi-volume archive."""
 
         whence = self._cur.add_size - self._cur_avail
-        self._fd.seek(self._inf.header_offset, self._cur.add_size - self._cur_avail)
+        self._fd.seek(self._inf.header_offset, whence)
         if whence == 0:
             self._cur = self._parser._parse_header(self._fd)
 


### PR DESCRIPTION
Before this PR, if we lazily read data from each file from Rar Archive, the `fd` would change to wrong location to start reading.
After this PR, we reset `fd` to corresponding offset for each DirectReader instance.


@markokr 