### PR TITLE
adapt to Python 3.10 argparse

### DIFF
--- a/test/test_tool.py
+++ b/test/test_tool.py
@@ -128,5 +128,5 @@ def test_cli_extract(capsys, tmp_path):
 def test_cli_help(capsys):
     assert cli("--help") == 0
     res = capsys.readouterr()
-    assert "optional" in res.out
+    assert "option" in res.out
 


### PR DESCRIPTION
From Python 3.10 changelog: Misleading phrase “optional arguments” was replaced with “options” in argparse help. Some tests might require adaptation if they rely on exact output match.

This is just a proposal, if you think of a better substring to match, go for it.