### PR TITLE
Use OS separator to access filename

### DIFF
--- a/rarfile.py
+++ b/rarfile.py
@@ -1302,7 +1302,7 @@ class CommonParser:
         # not giving filename avoids encoding related problems
         fn = None
         if not tmpfile or force_file:
-            fn = inf.filename
+            fn = inf.filename.replace("/", os.path.sep)
 
         # read from unrar pipe
         cmd = setup.open_cmdline(pwd, rarfile, fn)


### PR DESCRIPTION
#69 only partially fixed #68, ignored that `orig_filename` is bytes, so it will fail if the filename contains non-ascii characters. 

In fact, if we are not accessing the contained files via a temporary file, e.g. extracting encrypted/solid RAR, then `unrar` requires the OS-specific separator to work, so '\\' doesn't work on Linux either - just like that '/' won't work on Windows.

Instead of decoding `orig_filename` , we can simply replace the forward slash in decoded `filename` with `os.path.sep`, which should be a better solution.

Closing #68
Replace #69