### PR TITLE
Fix reparse RAR5 with header encryption when password changes

### DIFF
--- a/rarfile.py
+++ b/rarfile.py
@@ -2049,6 +2049,8 @@ class RAR5Parser(CommonParser):
             raise RarWrongPassword()
 
     def _parse_encryption_block(self, h, hdata, pos):
+        self._hdrenc_main = h
+        self._needs_password = True
         h.encryption_algo, pos = load_vint(hdata, pos)
         h.encryption_flags, pos = load_vint(hdata, pos)
         h.encryption_kdf_count, pos = load_byte(hdata, pos)
@@ -2059,7 +2061,6 @@ class RAR5Parser(CommonParser):
             raise BadRarFile("Unsupported header encryption cipher")
         if h.encryption_check_value and self._password:
             self._check_password(h.encryption_check_value, h.encryption_kdf_count, h.encryption_salt)
-        self._hdrenc_main = h
         return h
 
     def _process_file_extra(self, h, xdata):

--- a/test/test_format.py
+++ b/test/test_format.py
@@ -93,6 +93,10 @@ def test_rar5_header_encryption():
     assert r.comment is None
     assert r.namelist() == []
 
+    with pytest.raises(rarfile.RarWrongPassword):
+        r.setpassword("password222")
+    assert r.needs_password() is True
+
     r.setpassword("password")
     assert r.needs_password() is True
     assert r.namelist() == ["stest1.txt", "stest2.txt"]


### PR DESCRIPTION
If you parse RAR5 with header encryption but with the wrong password then subsequent calls to `setpassword` do not reparse the file, because it raises in `_check_password` before assignment.

Therefore calls to `self._file_parser.has_header_encryption()` return `False`.